### PR TITLE
Fix in-combat tooltip errors and replace deprecated GetItemQualityColor

### DIFF
--- a/src/CollectMe.lua
+++ b/src/CollectMe.lua
@@ -871,7 +871,7 @@ function CollectMe:SlashProcessor(input)
 end
 
 function CollectMe:ColorizeByQuality(text, quality)
-    local color = "|C" .. select(4, GetItemQualityColor(quality))
+    local color = (ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality] and ITEM_QUALITY_COLORS[quality].hex) or "|cffffffff"
     return color .. text .. FONT_COLOR_CODE_CLOSE;
 end
 

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -11,6 +11,10 @@ function CollectMe.Tooltip:TooltipHook(tooltip)
     if self.gametooltip_visible == true or CollectMe.db.profile.tooltip.companions.hide == true then
         return
     end
+    -- UnitIsWildBattlePet/UnitGUID reject secret values during combat; return early to avoid errors
+    if InCombatLockdown() then
+        return
+    end
 
     self.gametooltip_visible = true
     if (tooltip and tooltip.GetUnit) then

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -19,8 +19,18 @@ function CollectMe.Tooltip:TooltipHook(tooltip)
     self.gametooltip_visible = true
     if (tooltip and tooltip.GetUnit) then
         local _, unit = tooltip:GetUnit()
-        if (unit and UnitIsWildBattlePet(unit)) then
-            local creature_id = tonumber(select(6,strsplit("-",UnitGUID(unit))),10)
+        local ok, is_wild = pcall(UnitIsWildBattlePet, unit)
+        if not ok or not is_wild then
+            self.gametooltip_visible = false
+            return
+        end
+        local guid_ok, guid = pcall(UnitGUID, unit)
+        if not guid_ok or not guid then
+            self.gametooltip_visible = false
+            return
+        end
+        local creature_id = tonumber(select(6, strsplit("-", guid)), 10)
+        if creature_id then
             local line
             for i,v in ipairs(CollectMe.CompanionDB:Get()) do
                 if(creature_id == v.creature_id) then


### PR DESCRIPTION
- Tooltip: Return early when InCombatLockdown() to avoid secret-value errors. UnitIsWildBattlePet and UnitGUID reject unit tokens from tooltip:GetUnit() during tainted execution.

- CollectMe: Replace deprecated GetItemQualityColor (10.2.6) with ITEM_QUALITY_COLORS table. ColorizeByQuality now uses ITEM_QUALITY_COLORS[quality].hex with fallback to white when quality is nil or out of range.range